### PR TITLE
left not inner join

### DIFF
--- a/batch-processing-gold-2/Batch Processing - Gold - Solutions.py
+++ b/batch-processing-gold-2/Batch Processing - Gold - Solutions.py
@@ -124,7 +124,7 @@ display(start_transaction_response_df.transform(match_start_transaction_requests
 ########## SOLUTION ##########
 def match_start_transaction_requests_with_responses(input_df: DataFrame, join_df: DataFrame) -> DataFrame:
     ### YOUR CODE HERE
-    join_type: str = "inner"
+    join_type: str = "left"
     ###
     return input_df.\
         join(join_df, input_df.message_id == join_df.message_id, join_type).\


### PR DESCRIPTION
Here the instructs say to use a left join:

https://github.com/ryandawsonuk/exercise-ev-databricks/blob/54cfe9ce55904d92da6808bd26e28a0210834be8/batch-processing-gold-2/Batch%20Processing%20-%20Gold%20-%20Solutions.py#L94

But the solution uses an inner join. They actually give the same results as it happens that all requests do have responses. But conceptually I think a left join is intended